### PR TITLE
Add option to exclude local background in residual image (#1690)

### DIFF
--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1033,10 +1033,10 @@ class PSFPhotometry:
 
         Parameters
         ----------
-        shape : tuple of int
+        shape : 2 tuple of int
             The shape of the output array.
 
-        psf_shape : tuple of int
+        psf_shape : 2 tuple of int
             The shape of region around the center of the fit model to
             render in the output image.
 
@@ -1047,7 +1047,7 @@ class PSFPhotometry:
 
         Returns
         -------
-        array : `numpy.ndarray`
+        array : 2D `~numpy.ndarray`
             The rendered image from the fit PSF models.
         """
         fit_models = self._fit_models
@@ -1068,7 +1068,7 @@ class PSFPhotometry:
             y0 = getattr(fit_model, yname).value
             try:
                 slc_lg, _ = overlap_slices(shape, psf_shape, (y0, x0),
-                                            mode='trim')
+                                           mode='trim')
             except NoOverlapError:
                 continue
             yy, xx = np.mgrid[slc_lg]

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1109,7 +1109,8 @@ class PSFPhotometry:
         """
         if isinstance(data, NDData):
             residual = deepcopy(data)
-            residual.data[:] = self.make_residual_image(data.data, psf_shape, include_bkg)
+            residual.data[:] = self.make_residual_image(data.data, psf_shape, 
+                                                        include_localbkg=include_localbkg)
         else:
             unit = None
             if isinstance(data, u.Quantity):

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1080,7 +1080,7 @@ class PSFPhotometry:
 
         return data
 
-    def make_residual_image(self, data, psf_shape, include_bkg=True):
+    def make_residual_image(self, data, psf_shape, include_localbkg=True):
         """
         Create a 2D residual image from the fit PSF models and local
         background.

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1107,14 +1107,14 @@ class PSFPhotometry:
         """
         if isinstance(data, NDData):
             residual = deepcopy(data)
-            residual.data[:] = self.make_residual_image(data.data, psf_shape, 
+            residual.data[:] = self.make_residual_image(data.data, psf_shape,
                                                         include_localbkg=include_localbkg)
         else:
             unit = None
             if isinstance(data, u.Quantity):
                 unit = data.unit
                 data = data.value
-            residual = self.make_model_image(data.shape, psf_shape, 
+            residual = self.make_model_image(data.shape, psf_shape,
                                              include_localbkg=include_localbkg)
             np.subtract(data, residual, out=residual)
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1027,7 +1027,7 @@ class PSFPhotometry:
 
         return source_tbl
 
-    def make_model_image(self, shape, psf_shape, include_bkg=True):
+    def make_model_image(self, shape, psf_shape, include_localbkg=True):
         """
         Create a 2D image from the fit PSF models and local background.
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1096,7 +1096,7 @@ class PSFPhotometry:
             The shape of region around the center of the fit model to
             subtract.
 
-        include_bkg : bool, optional
+        include_localbkg : bool, optional
             Whether to include the local background in the subtracted
             model.
             Default is True.

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1115,7 +1115,8 @@ class PSFPhotometry:
             if isinstance(data, u.Quantity):
                 unit = data.unit
                 data = data.value
-            residual = self.make_model_image(data.shape, psf_shape, include_bkg)
+            residual = self.make_model_image(data.shape, psf_shape, 
+                                             include_localbkg=include_localbkg)
             np.subtract(data, residual, out=residual)
 
             if unit is not None:

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1072,11 +1072,9 @@ class PSFPhotometry:
             except NoOverlapError:
                 continue
             yy, xx = np.mgrid[slc_lg]
-            if include_bkg:
-                model = (fit_model(xx, yy) + local_bkg)
-            else:
-                model = fit_model(xx, yy)
-            data[slc_lg] += model
+            data[slc_lg] += fit_model(xx, yy)
+            if include_localbkg:
+                data[slc_lg] += local_bkg
 
         return data
 

--- a/photutils/psf/photometry.py
+++ b/photutils/psf/photometry.py
@@ -1040,7 +1040,7 @@ class PSFPhotometry:
             The shape of region around the center of the fit model to
             render in the output image.
 
-        include_bkg : bool, optional
+        include_localbkg : bool, optional
             Whether to include the local background in the rendered
             output image.
             Default is True.


### PR DESCRIPTION
This pull request is to solve issue #1690. I added a new keyword to the function `make_model_image' and `make_residual_image' of the PSFPhotometry-class to toggle whether the local background is included or not.

> At the moment it is only possible to make a model image of the fitted PSF Photometry that includes the locally measured background for each star. However, when there is highly structures background and a crowded field, it may be desirable to only subtract a model of the fit stars from the image, without the local background estimate (that currently can only be a scalar). Otherwise we have overlapping regions of subtracted scalar backgrounds in the residual image when stars are close to each other.
> This option may also be useful for iterative PSF fitting of clustered stars.
> The solution would simply to add one more parameter ``include_bkg'' to both functions in the PSFPhotometry-class.